### PR TITLE
Allow passing env file as a parameter.

### DIFF
--- a/install/ansible/install.sh
+++ b/install/ansible/install.sh
@@ -71,10 +71,6 @@ mkdir -p $inventory
 host_inventory="$inventory/contiv_hosts"
 node_info="$inventory/contiv_nodes"
 
-# Load any additional extra parameters. This needs to be done after the default setting
-# to allow user to override the values
-. $installer_config
-
 ./genInventoryFile.py $contiv_config $host_inventory $node_info $contiv_network_mode $fwd_mode
 
 cluster="etcd://$netmaster:2379"
@@ -90,6 +86,12 @@ sed -i.bak "s#__CLUSTER_STORE__#$cluster#g" $env_file
 # Copy certs
 cp /var/contiv/cert.pem /ansible/roles/auth_proxy/files/
 cp /var/contiv/key.pem /ansible/roles/auth_proxy/files/
+
+# Override extra vars file, if one is provided.
+if [[ -f $installer_config ]]; then
+  mv $env_file $env_file.bak
+  cp $installer_config $env_file
+fi
 
 echo "Installing Contiv"
 # TODO: rather than running them separately - merge the playbooks, that makes error tracking simpler

--- a/install/ansible/install_swarm.sh
+++ b/install/ansible/install_swarm.sh
@@ -91,11 +91,6 @@ if [[ ! -f $host_contiv_config ]]; then
   usage
 fi
 
-if [[ ! -f $host_installer_config ]]; then
-	touch $host_installer_config
-  echo "Created host_installer_config"
-fi
-
 if [[ "$netmaster" = ""  ]]; then
 	echo "Netmaster IP/name is missing"
   usage
@@ -127,7 +122,7 @@ rm -rf $src_conf_path
 echo "Installation is complete"
 echo "========================================================="
 echo " "
-echo "Please export DOCKER_HOST=$netmaster:2375 in your shell before proceeding"
-echo "Contiv UI is available at https://$netmaster:10000
+echo "Please export DOCKER_HOST=tcp://$netmaster:2375 in your shell before proceeding"
+echo "Contiv UI is available at https://$netmaster:10000"
 echo " "
 echo "========================================================="

--- a/install/ansible/uninstall.sh
+++ b/install/ansible/uninstall.sh
@@ -71,10 +71,6 @@ mkdir -p $inventory
 host_inventory="$inventory/contiv_hosts"
 node_info="$inventory/contiv_nodes"
 
-# Load any additional extra parameters. This needs to be done after the default setting
-# to allow user to override the values
-. $installer_config
-
 ./genInventoryFile.py $contiv_config $host_inventory $node_info $contiv_network_mode $fwd_mode
 
 cluster="etcd://$netmaster:2379"
@@ -86,6 +82,12 @@ ansible_path=./ansible
 env_file=install/ansible/env.json
 sed -i.bak "s/__NETMASTER_IP__/$netmaster/g" $env_file
 sed -i.bak "s#__CLUSTER_STORE__#$cluster#g" $env_file
+
+# Override extra vars file, if one is provided.
+if [[ -f $installer_config ]]; then
+  mv $env_file $env_file.bak
+  cp $installer_config $env_file
+fi
 
 echo "Uninstalling Contiv"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -97,9 +97,9 @@ chmod +x $output_dir/install/install.sh
 chmod +x $k8s_yaml_dir/install.sh
 chmod +x $k8s_yaml_dir/uninstall.sh
 chmod +x $ansible_yaml_dir/install_swarm.sh
-sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$auth_proxy_version/g" $ansible_yaml_dir/install_swarm.sh
+sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$VERSION/g" $ansible_yaml_dir/install_swarm.sh
 chmod +x $ansible_yaml_dir/uninstall_swarm.sh
-sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$auth_proxy_version/g" $ansible_yaml_dir/uninstall_swarm.sh
+sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$VERSION/g" $ansible_yaml_dir/uninstall_swarm.sh
 
 # Cleanup the backup files
 rm -f $k8s_yaml_dir/*.bak


### PR DESCRIPTION
With the addition of network mode and fwd mode as command line params,
there is no additional host config required. So reusing the file to
override env vars. This is useful for cases where you want to point to a
private repo - change images names etc as these are currently hardcoded
for a release.