### PR TITLE
Fix aws install

### DIFF
--- a/install/ansible/install_swarm.sh
+++ b/install/ansible/install_swarm.sh
@@ -39,7 +39,7 @@ Additional Options:
 Advanced Options:
 -v   string     ACI Image (default is contiv/aci-gw:latest). Use this to specify a specific version of the ACI Image.
 -n   string     DNS name/IP address of the host to be used as the net master service VIP. This must be a host present in the cfg.yml file.
--s   string     URL of the cluster store to be used (for example etcd://etcd_master:2379)
+-s   string     URL of the cluster store to be used (for example etcd://etcd master or netmaster IP:2379)
 Additional parameters can also be updated in install/ansible/env.json file.
 
 Examples:

--- a/install/ansible/uninstall_swarm.sh
+++ b/install/ansible/uninstall_swarm.sh
@@ -35,7 +35,7 @@ Advanced Options:
 -n   string     DNS name/IP address of the host to be used as the net master service VIP. This must be a host present in the cfg.yml file.
 -r              Reset etcd state and remove docker containers
 -g              Remove docker images
--s   string     URL of the cluster store to be used (for example etcd://etcd_master:2379)
+-s   string     URL of the cluster store to be used (for example etcd://etcd master or netmaster IP:2379)
 Additional parameters can also be updated in install/ansible/env.json file.
 
 Examples:

--- a/install/genInventoryFile.py
+++ b/install/genInventoryFile.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+
+import sys
+import yaml
+
+NW_MODE_STANDALONE = 'standalone'
+NW_MODE_ACI = 'aci'
+
+class SafeDict(dict):
+    'Provide a default value for missing keys'
+    def __missing__(self, key):
+        return 'missing'
+
+class Inventory:
+    groupName = "netplugin-node"
+    masterGroupName = "netplugin-master"
+    workerGroupName = "netplugin-worker"
+
+    def __init__(self, args):
+        self.cfgFile = args[0]
+        self.inventoryFile = args[1]
+        self.nodeInfoFile = args[2]
+        self.networkMode = args[3].lower()
+        self.fwdMode = args[4]
+    def parseConfigFile(self):
+        with open(self.cfgFile) as inFd:
+            config = yaml.load(inFd)
+        self.configInfo = SafeDict(config)
+
+    def handleMissing(self, item, holder, fd):
+        print "ERROR No entry for {} in {}".format(item, holder)
+        fd.close()
+        sys.exit(1)
+
+    def writeInventoryEntry(self, outFd, config):
+        if self.configInfo[config] is 'missing':
+            self.handleMissing(config, self.cfgFile, outFd);
+        else:
+            cfg_entry = "{}={}\n".format(config.lower(), self.configInfo[config])
+            outFd.write(cfg_entry)
+
+    def writeInventory(self, outFd, groupName, groupRole):
+        outFd.write("[" + groupName + "]\n")
+        connInfo = SafeDict(self.configInfo['CONNECTION_INFO'])
+
+        # Add host entries in the inventory file
+        for node in connInfo:
+            role = connInfo[node].get('role', 'worker')
+            if role != groupRole:
+                continue
+            var_line = "node{} ".format(self.nodeCount)
+            outFd.write(var_line)
+            var_line = "ansible_ssh_host={} ".format(node)
+            outFd.write(var_line)
+            var_line = "control_interface={} ".format(connInfo[node]['control'])
+            outFd.write(var_line)
+            var_line = "netplugin_if={} \n".format(connInfo[node]['data'])
+            outFd.write(var_line)
+
+            self.nodeCount += 1
+
+        outFd.write("\n")
+
+    def writeGlobalVars(self, outFd):
+        outFd.write("[" + "all:vars]\n")
+        var_line = "fwd_mode={}\n".format(self.fwdMode)
+        outFd.write(var_line)
+        var_line = "contiv_network_mode={}\n".format(self.networkMode)
+        outFd.write(var_line)
+
+        # write group vars if network mode is ACI
+        if self.networkMode == NW_MODE_ACI:
+            self.writeInventoryEntry(outFd, 'APIC_URL')
+            self.writeInventoryEntry(outFd, 'APIC_USERNAME')
+            self.writeInventoryEntry(outFd, 'APIC_PASSWORD')
+            self.writeInventoryEntry(outFd, 'APIC_PHYS_DOMAIN')
+            self.writeInventoryEntry(outFd, 'APIC_EPG_BRIDGE_DOMAIN')
+            self.writeInventoryEntry(outFd, 'APIC_CONTRACTS_UNRESTRICTED_MODE')
+
+            if self.configInfo['APIC_LEAF_NODES'] is 'missing':
+                self.handleMissing("APIC_LEAF_NODES", self.cfgFile, outFd);
+
+            if self.configInfo['APIC_LEAF_NODES'] is None:
+                self.handleMissing("APIC_LEAF_NODES", self.cfgFile, outFd);
+            else:
+                leafCount = 0
+                leafStr = "apic_leaf_nodes="
+                for leaf in self.configInfo['APIC_LEAF_NODES']:
+                    if leafCount > 0:
+                        leafStr += ","
+
+                    leafStr += leaf
+                    leafCount += 1
+
+                # if no leaf was found, treat as error
+                if leafCount == 0:
+                    self.handleMissing("APIC_LEAF_NODES", self.cfgFile, outFd);
+                
+                leafStr += "\n"
+                outFd.write(leafStr)
+
+    def writeNodeInfo(self):
+        with open(self.nodeInfoFile, "w+") as nodeInfoFd:
+            # Node count starts from 1 and is incremented for
+            # each node. So the actual number of nodes is nodeCount -1
+            node_info = "{}".format(self.nodeCount - 1)
+            nodeInfoFd.write(node_info)
+
+    def writeInventoryFile(self):
+        with open(self.inventoryFile, "w+") as outFd:
+            self.nodeCount = 1
+            self.writeInventory(outFd, Inventory.masterGroupName, "master")
+            self.writeInventory(outFd, Inventory.workerGroupName, "worker")
+            # The main group containing both the master and worker nodes
+            outFd.write("[" + Inventory.groupName + ":children]\n")
+            outFd.write(Inventory.masterGroupName + "\n")
+            outFd.write(Inventory.workerGroupName + "\n\n")
+            self.writeGlobalVars(outFd)
+
+if __name__ == "__main__":
+    inv = Inventory(sys.argv[1:])
+
+    inv.parseConfigFile()
+
+    inv.writeInventoryFile()
+
+    inv.writeNodeInfo()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -68,7 +68,6 @@ cp -rf install $output_dir
 cp -rf scripts/generate-certificate.sh $output_dir/install
 
 # Get the ansible support files
-curl -sSL -o $output_dir/install/genInventoryFile.py https://raw.githubusercontent.com/contiv/demo/master/net/extras/genInventoryFile.py
 chmod +x $output_dir/install/genInventoryFile.py
 chmod +x $output_dir/install/generate-certificate.sh
 
@@ -146,9 +145,6 @@ fi
 aci_image=$(docker images -q contiv/aci-gw:$aci_gw_version)
 docker save $aci_image -o $binary_cache/aci-gw-image.tar
 
-curl -ksL -o $binary_cache/openvswitch-2.3.1-2.el7.x86_64.rpm  https://cisco.box.com/shared/static/zzmpe1zesdpf270k9pml40rlm4o8fs56.rpm
-curl -ksL -o $binary_cache/v1dvgoboo5zgqrtn6tu27vxeqtdo2bdl.deb https://cisco.box.com/shared/static/v1dvgoboo5zgqrtn6tu27vxeqtdo2bdl.deb
-curl -ksL -o $binary_cache/ymbuwvt2qprs4tquextw75b82hyaxwon.deb https://cisco.box.com/shared/static/ymbuwvt2qprs4tquextw75b82hyaxwon.deb
 curl -sL -o $binary_cache/netplugin-$contiv_version.tar.bz2 https://github.com/contiv/netplugin/releases/download/$contiv_version/netplugin-$contiv_version.tar.bz2
 
 env_file=$output_dir/install/ansible/env.json


### PR DESCRIPTION
Fixes #27. Current security group opens all ports between the VMs but not externally. So using external public IP for cluster store does not work. Changing it to use private IP by default and specify the cluster store public IP explicitly with the -s cluster_store option where etcd is accessible using public IP.

scripts/release.sh file change is not directly related, but required due to the box folder deletion.
I've also moved the genInventoryFile.py locally to contiv/install to handle the contiv/demo deprecation.

Tested that provision.sh works with new SG as well as old and that explicitly specifying public IP for the cluster store works as well.

We can further customize this by adding a field for node IP to use for netmaster & etcd for each node in the cfg.yml. I haven't worked on that yet. 