### PR TITLE
Dockerfile: uninstall dev tools to shrink image

### DIFF
--- a/install/ansible/Dockerfile
+++ b/install/ansible/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.5
 MAINTAINER contiv
 
-RUN apk add --no-cache python-dev py-pip gcc musl-dev openssl-dev libffi-dev && \
-    pip install --upgrade pip && pip install ansible==2.2.0.0
+RUN DEV_PACKAGES="python-dev py-pip gcc musl-dev openssl-dev libffi-dev" \
+ && apk add --no-cache python openssl libffi $DEV_PACKAGES \
+ && pip install --upgrade pip \
+ && pip install ansible==2.2.1.0 \
+ && apk del $DEV_PACKAGES


### PR DESCRIPTION
This PR modifies the Dockerfile to reduce the size of the image. The original size of the image was 220 MB. The new image is only 87.5 MB.