### PR TITLE
Removing firewall disable as Vagrantfile does it

### DIFF
--- a/cluster/bootstrap_centos.sh
+++ b/cluster/bootstrap_centos.sh
@@ -21,6 +21,3 @@ yum install -y docker kubelet kubeadm kubectl kubernetes-cni
 systemctl enable docker && systemctl start docker
 systemctl enable kubelet && systemctl start kubelet
 
-systemctl stop firewalld
-systemctl disable firewalld
-


### PR DESCRIPTION
Jenkins hosts are failing this step and it is unnecessary for Vagrant setups.