### PR TITLE
Set k8s install/uninstall scripts to abort on errors and unbound variables

### DIFF
--- a/install/k8s/install.sh
+++ b/install/k8s/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# This is the uninstall script for Contiv.
+# This is the install script for Contiv.
+
+set -euo pipefail
 
 #
 # The following parameters are user defined - and vary for each installation

--- a/install/k8s/uninstall.sh
+++ b/install/k8s/uninstall.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 if [ "$1" = "-h" ]; then
   echo "Usage: ./install/k8s/uninstall.sh to uninstall contiv"
   echo "       ./install/k8s/uninstall.sh etcd-cleanup to uninstall contiv and cleanup contiv data"


### PR DESCRIPTION
@dojacobs give this a try:

```
git remote add dseevr git@github.com:dseevr/install.git
git fetch dseevr
git checkout -t dseevr/k8s_errors
```