### PR TITLE
Fix 57: Allow specifying ProxyCommand ansible option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ build:
 	rm -rf release/
 	@bash ./scripts/build.sh
 
+# ansible-image creates the docker image for ansible container
+# It uses the version specified by BUILD_VERSION or creates an image with the latest tag.
+ansible-image:
+	@bash ./scripts/build_image.sh
+
 # Brings up a demo cluster to install Contiv on - by default this is a docker, centos cluster.
 # It can be configured to start a RHEL cluster by setting CONTIV_NODE_OS=rhel7.
 # It can be started with k8s kubeadm install by running with CONTIV_KUBEADM=1.

--- a/install/ansible/Dockerfile
+++ b/install/ansible/Dockerfile
@@ -1,8 +1,6 @@
-FROM alpine:3.5
+FROM alpine
 MAINTAINER contiv
 
-RUN DEV_PACKAGES="python-dev py-pip gcc musl-dev openssl-dev libffi-dev" \
- && apk add --no-cache python openssl libffi $DEV_PACKAGES \
- && pip install --upgrade pip \
- && pip install ansible==2.2.1.0 \
- && apk del $DEV_PACKAGES
+RUN apk add --no-cache python openssl libffi \
+    py-pip ansible nmap-ncat 
+

--- a/install/ansible/install_swarm.sh
+++ b/install/ansible/install_swarm.sh
@@ -134,7 +134,12 @@ if [[ -f $ans_key ]]; then
   cp "$ans_key" "$host_ans_key"
 fi
 
-ans_opts="$ans_opts --private-key $def_ans_key -u $ans_user"
+if [ "$ans_opts" == "" ]; then
+  ans_opts=" --private-key $def_ans_key -u $ans_user"
+else
+  ans_opts=$(printf '%q', $ans_opts)" --private-key $def_ans_key -u $ans_user"
+fi
+
 
 # Generate SSL certs for auth proxy
 if [[ ! -f "$host_tls_cert" || ! -f "$host_tls_key" ]]; then

--- a/install/ansible/uninstall_swarm.sh
+++ b/install/ansible/uninstall_swarm.sh
@@ -130,7 +130,11 @@ if [[ -f $ans_key ]]; then
   cp "$ans_key" "$host_ans_key"
 fi
 
-ans_opts="$ans_opts --private-key $def_ans_key -u $ans_user"
+if [ "$ans_opts" == "" ]; then
+  ans_opts=" --private-key $def_ans_key -u $ans_user"
+else
+  ans_opts=$(printf '%q', $ans_opts)" --private-key $def_ans_key -u $ans_user"
+fi
 echo "Starting the uninstaller container"
 image_name="contiv/install:__CONTIV_INSTALL_VERSION__"
 install_mount="-v $(pwd)/install:/install:Z"

--- a/install/k8s/install.sh
+++ b/install/k8s/install.sh
@@ -239,7 +239,8 @@ echo "$netmaster netmaster" >> /etc/hosts
 echo "To customize the installation press Ctrl+C and edit $contiv_yaml."
 sleep 5
 chmod +x ./netctl
-mv ./netctl /usr/bin/
+rm -f /usr/bin/netctl
+cp ./netctl /usr/bin/
 # Install Contiv
 kubectl apply -f $contiv_yaml
 if [ "$fwd_mode" = "routing" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,6 +11,7 @@ aci_gw_version=${CONTIV_ACI_GW_VERSION:-"latest"}
 contiv_version=${CONTIV_VERSION:-"1.0.0-beta.3"}
 etcd_version=${CONTIV_ETCD_VERSION:-2.3.7}
 docker_version=${CONTIV_DOCKER_VERSION:-1.12.6}
+ansible_image_version=${CONTIV_ANSIBLE_IMAGE_VERSION:-"1.0.0-beta.3.1"}
 
 function usage() {
 	echo "Usage:"
@@ -102,8 +103,8 @@ sed -i.bak "s/__ETCD_VERSION__/$etcd_version/g" $ansible_env
 
 chmod +x $k8s_yaml_dir/install.sh
 chmod +x $k8s_yaml_dir/uninstall.sh
-sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$VERSION/g" $ansible_yaml_dir/install_swarm.sh
-sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$VERSION/g" $ansible_yaml_dir/uninstall_swarm.sh
+sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$ansible_image_version/g" $ansible_yaml_dir/install_swarm.sh
+sed -i.bak "s/__CONTIV_INSTALL_VERSION__/$ansible_image_version/g" $ansible_yaml_dir/uninstall_swarm.sh
 chmod +x $ansible_yaml_dir/install_swarm.sh
 chmod +x $ansible_yaml_dir/uninstall_swarm.sh
 chmod +x $output_dir/install/ansible/install.sh
@@ -112,17 +113,10 @@ chmod +x $output_dir/install/ansible/uninstall.sh
 rm -f $k8s_yaml_dir/*.bak
 rm -f $ansible_yaml_dir/*.bak
 
-# Build the docker container for ansible installation
-ansible_spec=$output_dir/install/ansible/Dockerfile
-docker build -t contiv/install:$VERSION -f $ansible_spec $output_dir
-
 rm -rf $output_dir/scripts
-echo "**************************************************************************************************"
-echo " Please ensure that contiv/install:$VERSION is pushed to docker hub"
-echo "**************************************************************************************************"
 
 # Clean up the Dockerfiles, they are not part of the release bits.
-rm -f $ansible_spec
+rm -f $output_dir/install/ansible/Dockerfile
 
 # Create the binary cache folder
 binary_cache=$output_dir/contiv_cache

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+VERSION=${BUILD_VERSION-"latest"}
+
+# Build the docker container for ansible installation
+ansible_spec=./install/ansible/Dockerfile
+docker build -t contiv/install:$VERSION -f $ansible_spec .
+


### PR DESCRIPTION
This requires escaping the ans_opts variable as the syntax for
ProxyCommand requires a quote. ProxyCommand spec requires ncat to be
installed in the container. So creating a new version of the ansible
container and separating it from the installer build.
Now we can build and release the ansible container separately.
Updating the sed statements for env.json update to handle the case where
there are pre-existing values. This is required to repeat a failed
install.