### PR TITLE
scripts/build.sh: prepare changes for beta.4

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,12 +6,12 @@ DEV_IMAGE_NAME="devbuild"
 IMAGE_NAME="contiv/auth_proxy"
 VERSION=${BUILD_VERSION-$DEV_IMAGE_NAME}
 
-auth_proxy_version=${CONTIV_API_PROXY_VERSION:-"1.0.0-beta.3"}
+auth_proxy_version=${CONTIV_API_PROXY_VERSION:-"1.0.0-beta.4"}
 aci_gw_version=${CONTIV_ACI_GW_VERSION:-"latest"}
-contiv_version=${CONTIV_VERSION:-"1.0.0-beta.3-03-08-2017.18-51-20.UTC"}
-etcd_version=${CONTIV_ETCD_VERSION:-2.3.7}
+contiv_version=${CONTIV_VERSION:-"1.0.0-beta.4"}
+etcd_version=${CONTIV_ETCD_VERSION:-2.3.8}
 docker_version=${CONTIV_DOCKER_VERSION:-1.12.6}
-ansible_image_version=${CONTIV_ANSIBLE_IMAGE_VERSION:-"1.0.0-beta.3.1"}
+ansible_image_version=${CONTIV_ANSIBLE_IMAGE_VERSION:-"1.0.0-beta.4"}
 
 function usage() {
 	echo "Usage:"


### PR DESCRIPTION
This PR still needs the final netplugin 1.0.0-beta.4 release to be made.

etcd is bumped to 2.3.8.