### PR TITLE
scripts/{release,build}: check working dir & cd

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+# ensure this script wasn't called from the directory where this script
+# lives; it should be called from the repository's top level
+script_dir="$(dirname -- "$0")"
+if [ "$script_dir" == "." ]; then
+	echo "This script must be called from the top level of the repository"
+	exit 1
+fi
+
 DEV_IMAGE_NAME="devbuild"
 IMAGE_NAME="contiv/auth_proxy"
 VERSION=${BUILD_VERSION-$DEV_IMAGE_NAME}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,6 +4,8 @@
 #  BUILD_VERSION - new version being released
 #  GITHUB_USER - contiv
 #  GITHUB_TOKEN - your github token
+cd -P -- "$(dirname -- "$0")"
+
 if [ -z "$BUILD_VERSION" ]; then
 	echo "A release requires BUILD_VERSION to be defined""
 	exit 1


### PR DESCRIPTION
This ensures these mistakes are caught easily. There's no need to spend time investigating issues related to this.