### PR TITLE
Run installer for k8s with explicit sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Contiv Docker Swarm installer is launched from a host external to the cluste
 If your access to the Internet is limited or slow and you want to download the full Contiv install, choose <br>
 `contiv-full-$VERSION.tgz`<br>
 Note: The full image contains only Contiv components. Installing Docker Swarm will need Internet connectivity.
-* Extract the install bundle <br>`tar xf contiv-$VERSION.tgz`.  
+* Extract the install bundle <br>`tar oxf contiv-$VERSION.tgz`.
 * Change directories to the extracted folder <br>`cd contiv-$VERSION`
 * To install Contiv with Docker Swarm:<br> `./install/ansible/install_swarm.sh -f cfg.yml -e <ssh key> -u <username> -i`
 * To install Contiv with Docker Swarm and ACI:<br> `./install/ansible/install_swarm.sh -f aci_cfg.yml -e <ssh key> -u <username> -i -m aci`
@@ -47,7 +47,7 @@ If you need to remove Contiv from Docker Swarm and return to your original state
 ### Contiv Installation
 * Run the following commands on the kubernetes master host.
 * Use curl to get the installer bundle: <br>`curl -L -O https://github.com/contiv/install/releases/download/$VERSION/contiv-$VERSION.tgz`
-* Extract the install bundle <br>`tar xf contiv-$VERSION.tgz`. 
+* Extract the install bundle <br>`tar oxf contiv-$VERSION.tgz`.
 * Change directories to the extracted folder <br>`cd contiv-$VERSION`
 * To install Contiv with VXLAN:<br> `sudo ./install/k8s/install.sh -n $CONTIV_MASTER`
 * To install Contiv specifying a data plane interface for VLAN:<br> `sudo ./install/k8s/install.sh -n $CONTIV_MASTER -v <data plane interface like eth1>`

--- a/install/k8s/auth_proxy.yaml
+++ b/install/k8s/auth_proxy.yaml
@@ -37,7 +37,6 @@ spec:
             - --tls-certificate=/var/contiv/auth_proxy_cert.pem
             - --data-store-address=$(CONTIV_ETCD)
             - --netmaster-address=__NETMASTER_IP__:9999
-            - --listen-address=__NETMASTER_IP__:10000
           env:
             - name: NO_NETMASTER_STARTUP_CHECK
               value: "1"

--- a/install/k8s/install.sh
+++ b/install/k8s/install.sh
@@ -3,6 +3,11 @@
 
 set -euo pipefail
 
+if [ $EUID -ne 0 ]; then
+  echo "Please run this script as root user"
+  exit 1
+fi
+
 #
 # The following parameters are user defined - and vary for each installation
 #
@@ -235,7 +240,7 @@ else
 fi
 
 echo "Applying contiv installation"
-echo "$netmaster netmaster" >> /etc/hosts
+grep -q -F "netmaster" /etc/hosts || echo "$netmaster netmaster" >> /etc/hosts
 echo "To customize the installation press Ctrl+C and edit $contiv_yaml."
 sleep 5
 chmod +x ./netctl
@@ -246,10 +251,10 @@ kubectl apply -f $contiv_yaml
 if [ "$fwd_mode" = "routing" ]; then
   sleep 60
   netctl --netmaster http://$netmaster:9999 global set --fwd-mode routing
-else
-  kubectl get deployment/kube-dns -n kube-system -o json  > kube-dns.yaml
-  kubectl delete deployment/kube-dns -n kube-system
 fi
+
+kubectl get deployment/kube-dns -n kube-system -o json  > kube-dns.yaml
+kubectl delete deployment/kube-dns -n kube-system
 
 echo "Installation is complete"
 echo "========================================================="

--- a/install/k8s/uninstall.sh
+++ b/install/k8s/uninstall.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-set -euo pipefail
+
+if [ $EUID -ne 0 ]; then
+  echo "Please run this script as root user"
+  exit 1
+fi
 
 if [ "$#" -eq 1 ] && [ "$1" = "-h" ]; then
   echo "Usage: ./install/k8s/uninstall.sh to uninstall contiv"
@@ -9,7 +13,7 @@ if [ "$#" -eq 1 ] && [ "$1" = "-h" ]; then
 fi
 
 # Delete the ACI secret if it is available
-kubectl delete secret aci.key -n kube-system || true
+kubectl delete secret aci.key -n kube-system
 
 # Delete Contiv pods
 kubectl delete -f .contiv.yaml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -76,7 +76,7 @@ chmod +x $output_dir/install/generate-certificate.sh
 # This is maybe optional - but assume we need it for
 curl -sSL https://github.com/contiv/netplugin/releases/download/$contiv_version/netplugin-$contiv_version.tar.bz2 -o $output_dir/netplugin-$contiv_version.tar.bz2
 pushd $output_dir
-tar xf netplugin-$contiv_version.tar.bz2 netctl
+tar oxf netplugin-$contiv_version.tar.bz2 netctl
 rm -f netplugin-$contiv_version.tar.bz2
 git clone http://github.com/contiv/ansible
 popd

--- a/scripts/kubeadm_test.sh
+++ b/scripts/kubeadm_test.sh
@@ -41,7 +41,7 @@ fi
 set +e # read returns 1 when it succeeds
 read -r -d '' COMMANDS <<-EOF
     sudo rm -rf ${install_version} && \\
-    ${curl_cmd} && tar xf ${install_version}.tgz && \\
+    ${curl_cmd} && tar oxf ${install_version}.tgz && \\
     cd ${install_version} && \\
     sudo ./install/k8s/install.sh -n ${contiv_master}
 EOF
@@ -53,7 +53,7 @@ CONTIV_KUBEADM=1 vagrant ssh contiv-node1 -- "$COMMANDS"
 set +e
 read -r -d '' SETUP_DEFAULT_NET <<-EOF
     cd ${install_version} && \\
-    sudo netctl net create -s ${default_net_cidr} default-net
+    netctl net create -s ${default_net_cidr} default-net
 EOF
 set -e
 
@@ -61,7 +61,7 @@ echo "*****************"
 # Wait for CONTIV to start for up to 10 minutes
 sleep 10
 for i in {0..20}; do
-	response=$(curl -k -H -s "Content-Type: application/json" -X POST -d '{"username": "admin", "password": "admin"}' https://$contiv_master:10000/api/v1/auth_proxy/login/ || true)
+	response=$(curl -k -s -H "Content-Type: application/json" -X POST -d '{"username": "admin", "password": "admin"}' https://$contiv_master:10000/api/v1/auth_proxy/login/ || true)
 	if [[ $response == *"token"* ]]; then
 		echo "Install SUCCESS"
 		echo ""

--- a/scripts/swarm_test.sh
+++ b/scripts/swarm_test.sh
@@ -32,14 +32,14 @@ if [ ! -f "${install_version}.tgz" ]; then
 	curl -L -O https://github.com/contiv/install/releases/download/${BUILD_VERSION}/${install_version}.tgz
 fi
 
-tar xf $install_version.tgz
+tar oxf $install_version.tgz
 cd $install_version
 ./install/ansible/install_swarm.sh -f ../../cluster/.cfg.yml -e $ssh_key -u $user -i
 
 # Wait for CONTIV to start for up to 10 minutes
 sleep 10
 for i in {0..20}; do
-	response=$(curl -k -H -s "Content-Type: application/json" -X POST -d '{"username": "admin", "password": "admin"}' https://$contiv_master:10000/api/v1/auth_proxy/login/ || true)
+	response=$(curl -k -s -H "Content-Type: application/json" -X POST -d '{"username": "admin", "password": "admin"}' https://$contiv_master:10000/api/v1/auth_proxy/login/ || true)
 	if [[ $response == *"token"* ]]; then
 		echo "Install SUCCESS"
 		echo ""


### PR DESCRIPTION
Removing explicit listen address specification for auth_proxy.
Also fixing the test curl command to avoid curl error messages while testing to see that the auth_proxy started.
Fixes https://github.com/contiv/install/issues/78