### PR TITLE
Adding explicit exit 0 to bootstrap scripts

### DIFF
--- a/cluster/k8s1.4/bootstrap_centos.sh
+++ b/cluster/k8s1.4/bootstrap_centos.sh
@@ -35,3 +35,5 @@ fi
 if systemctl -q is-enabled firewalld; then
 	systemctl disable firewalld
 fi
+
+exit 0

--- a/cluster/k8s1.6/bootstrap_centos.sh
+++ b/cluster/k8s1.6/bootstrap_centos.sh
@@ -30,3 +30,5 @@ fi
 if systemctl -q is-enabled firewalld; then
 	systemctl disable firewalld
 fi
+
+exit 0


### PR DESCRIPTION
Failure in the last evaluated command in the "if" is okay here, so we don't want to return its exit code. Return 0 if we get to the end of the script without an error.