### PR TITLE
install/ansible/Dockerfile: remove MAINTAINER

### DIFF
--- a/install/ansible/Dockerfile
+++ b/install/ansible/Dockerfile
@@ -1,5 +1,4 @@
 FROM alpine
-MAINTAINER contiv
 
 RUN apk add --no-cache python openssl libffi \
     py-pip ansible nmap-ncat 


### PR DESCRIPTION
The `MAINTAINER` instruction is being deprecated in Docker. This means we should also remove it from our Dockerfiles.