### PR TITLE
install/k8s/install.sh: ensure that /var/contiv is created even when a TLS cert is specified

### DIFF
--- a/install/k8s/install.sh
+++ b/install/k8s/install.sh
@@ -223,9 +223,10 @@ fi
 
 $kubectl create secret generic aci.key --from-file=$aci_key -n kube-system
 
+mkdir -p /var/contiv
+
 if [ "$tls_cert" = "" ]; then
 	echo "Generating local certs for Contiv Proxy"
-	mkdir -p /var/contiv
 	mkdir -p ./local_certs
 
 	chmod +x ./install/generate-certificate.sh


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>