### PR TITLE
scripts/get_latest_release.py: allow errors to go unhandled instead of returning a default version

### DIFF
--- a/scripts/get_latest_release.py
+++ b/scripts/get_latest_release.py
@@ -4,29 +4,13 @@ import json
 import requests
 import sys
 
-DEFAULT_VERSION = "1.0.0"
-
 HTTP_OK = 200
 
 # Try to get the latest release version
 r = requests.get("https://api.github.com/repos/contiv/install/releases/latest")
 if r.status_code != HTTP_OK:
-   # Get all the releases (include pre-releases) and pick the first of them
-   r = requests.get("https://api.github.com/repos/contiv/install/releases")
-   if r.status_code != HTTP_OK:
-      # Return a known version
-      print DEFAULT_VERSION
-      sys.exit(1)
-
-   try:
-      releases = json.loads(r.content)
-      print releases[0]['name']
-   except:
-      print DEFAULT_VERSION
-      sys.exit(1)
-try:
+   print >> sys.stderr, "failed to get latest release, status code: %d" % r.status_code
+   sys.exit(1)
+else:
    releases = json.loads(r.content)
    print releases['name']
-except:
-    print DEFAULT_VERSION
-    sys.exit(1)

--- a/scripts/get_latest_release.sh
+++ b/scripts/get_latest_release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Check if the user requested a specific build
 if [[ "$BUILD_VERSION" != "" ]]; then
 	echo $BUILD_VERSION
@@ -8,12 +9,11 @@ fi
 # Try to get the latest release
 releases=$(curl -s https://api.github.com/repos/contiv/install/releases/latest)
 if [[ "$releases" != *"browser_download_url"* ]]; then
-	releases=$(curl -s https://api.github.com/repos/contiv/install/releases)
-	if [[ "$releases" != *"browser_download_url"* ]]; then
-		exit 1
-	fi
-	release=$(echo "$releases" | python -c 'import json, sys;print json.load(sys.stdin)[0]["name"]')
-else
-	release=$(echo "$releases" | python -c 'import json, sys;print json.load(sys.stdin)["name"]')
+	echo >&2 "failed to get latest release"
+	exit 1
 fi
+
+release=$(echo "$releases" | python -c 'import json, sys;print json.load(sys.stdin)["name"]')
 echo $release
+
+exit 0


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>