### PR TITLE
Install bzip2, if it's not already there (like on AWS).

### DIFF
--- a/cluster/docker17/centos_prep.sh
+++ b/cluster/docker17/centos_prep.sh
@@ -9,6 +9,8 @@ fi
 
 setenforce 0
 
+yum install -y bzip2
+
 yum install -y ntp
 systemctl enable ntpd && systemctl start ntpd
 


### PR DESCRIPTION
Make sure bzip2 is installed because it's not installed with the Centos image we're using on AWS.