### PR TITLE
Merge netmaster and auth_proxy

### DIFF
--- a/install/k8s/k8s1.6/contiv.yaml
+++ b/install/k8s/k8s1.6/contiv.yaml
@@ -89,10 +89,8 @@ metadata:
   name: contiv-config
   namespace: kube-system
 data:
-  # The location of your cluster store. This is set to the
-  # avdertise-client value below from the contiv-etcd service.
-  # Change it to an external etcd/consul instance if required.
   cluster_store: "etcd://__NETMASTER_IP__:6666"
+  vlan_if: "__VLAN_IF__"
   # The CNI network configuration to install on each node.
   cni_config: |-
     {
@@ -146,10 +144,12 @@ spec:
           image: contiv/netplugin:__CONTIV_VERSION__
           args:
             - -pkubernetes
-            - -x
           env:
             - name: VLAN_IF
-              value: __VLAN_IF__
+              valueFrom:
+                configMapKeyRef:
+                  name: contiv-config
+                  key: vlan_if
             - name: VTEP_IP
               valueFrom:
                  fieldRef:
@@ -184,12 +184,6 @@ spec:
             - mountPath: /var/contiv
               name: var-contiv
               readOnly: false
-            - mountPath: /etc/kubernetes/pki
-              name: etc-kubernetes-pki
-              readOnly: false
-            - mountPath: /etc/kubernetes/ssl
-              name: etc-kubernetes-ssl
-              readOnly: false
             - mountPath: /opt/cni/bin
               name: cni-bin-dir
               readOnly: false
@@ -210,12 +204,6 @@ spec:
         - name: var-contiv
           hostPath:
             path: /var/contiv
-        - name: etc-kubernetes-pki
-          hostPath:
-            path: /etc/kubernetes/pki
-        - name: etc-kubernetes-ssl
-          hostPath:
-            path: /etc/kubernetes/ssl
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -249,7 +237,6 @@ spec:
       # The netmaster must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
-      hostPID: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -273,88 +260,17 @@ spec:
                 configMapKeyRef:
                   name: contiv-config
                   key: config
-          securityContext:
-            privileged: true
           volumeMounts:
-            - mountPath: /etc/openvswitch
-              name: etc-openvswitch
-              readOnly: false
-            - mountPath: /lib/modules
-              name: lib-modules
-              readOnly: false
-            - mountPath: /var/run
-              name: var-run
-              readOnly: false
             - mountPath: /var/contiv
               name: var-contiv
               readOnly: false
-            - mountPath: /etc/kubernetes/ssl
-              name: etc-kubernetes-ssl
-              readOnly: false
-            - mountPath: /opt/cni/bin
-              name: cni-bin-dir
-              readOnly: false
-      volumes:
-        # Used by contiv-netmaster
-        - name: etc-openvswitch
-          hostPath:
-            path: /etc/openvswitch
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
-        - name: var-run
-          hostPath:
-            path: /var/run
-        - name: var-contiv
-          hostPath:
-            path: /var/contiv
-        - name: etc-kubernetes-ssl
-          hostPath:
-            path: /etc/kubernetes/ssl
-        - name: cni-bin-dir
-          hostPath:
-            path: /opt/cni/bin
----
-
-# This manifest deploys the Contiv API Proxy Server on Kubernetes.
-apiVersion: extensions/v1beta1
-kind: ReplicaSet
-metadata:
-  name: contiv-api-proxy
-  namespace: kube-system
-  labels:
-    k8s-app: contiv-api-proxy
-spec:
-  # The API proxy should have 1, 3, 5 nodes of which one is active at any given time.
-  # More nodes are desired in a production environment for HA.
-  replicas: 1
-  template:
-    metadata:
-      name: contiv-api-proxy
-      namespace: kube-system
-      labels:
-        k8s-app: contiv-api-proxy
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-    spec:
-      # The API proxy must run in the host network namespace so that
-      # it isn't governed by policy that would prevent it from working.
-      hostNetwork: true
-      hostPID: true
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      serviceAccountName: contiv-netmaster
-      containers:
         - name: contiv-api-proxy
           image: contiv/auth_proxy:__CONTIV_VERSION__
           args:
             - --tls-key-file=/var/contiv/auth_proxy_key.pem
             - --tls-certificate=/var/contiv/auth_proxy_cert.pem
             - --data-store-address=$(CONTIV_ETCD)
-            - --netmaster-address=__NETMASTER_IP__:9999
+            - --netmaster-address=localhost:9999
           env:
             - name: NO_NETMASTER_STARTUP_CHECK
               value: "0"
@@ -370,9 +286,8 @@ spec:
               name: var-contiv
               readOnly: false
       volumes:
+        # Used by contiv-netmaster
         - name: var-contiv
           hostPath:
             path: /var/contiv
-
 ---
-


### PR DESCRIPTION
This also cleans up most of the unused mounts for netmaster & netplugin.
Removing the `-x` flag for netplugin. Lets deal with cleanup/upgrades separately.

This is the first part of HA implementation for Contiv on K8s. TBD is etcd HA - I am still trying to understand/decide whether to go with StatefulSets or use the etcd operator for this.

This resolves https://github.com/contiv/ccn/issues/95 and https://github.com/contiv/ccn/issues/319.