### PR TITLE
install/k8s/install.sh: only copy aci.key and cert/key if newer than the existing one

### DIFF
--- a/install/k8s/install.sh
+++ b/install/k8s/install.sh
@@ -217,7 +217,7 @@ if [ "$aci_key" = "" ]; then
 	aci_key=./aci.key
 	echo "dummy" >$aci_key
 else
-	cp $aci_key ./aci.key
+	cp -u $aci_key ./aci.key
 	aci_key=./aci.key
 fi
 
@@ -234,8 +234,8 @@ if [ "$tls_cert" = "" ]; then
 	tls_cert=./local_certs/cert.pem
 	tls_key=./local_certs/local.key
 fi
-cp $tls_cert /var/contiv/auth_proxy_cert.pem
-cp $tls_key /var/contiv/auth_proxy_key.pem
+cp -u $tls_cert /var/contiv/auth_proxy_cert.pem
+cp -u $tls_key /var/contiv/auth_proxy_key.pem
 
 echo "Setting installation parameters"
 sed -i.bak "s/__NETMASTER_IP__/$netmaster/g" $contiv_yaml


### PR DESCRIPTION
Currently, running install.sh when an ACI key or TLS cert/key already exist results in `cp` failing and aborting the entire script.

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>