### PR TITLE
scripts/get_latest_release.sh: switch to python3-friendly print statement (backwards compatible with python2)

### DIFF
--- a/scripts/get_latest_release.sh
+++ b/scripts/get_latest_release.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Check if the user requested a specific build
-if [[ "$BUILD_VERSION" != "" ]]; then
+if [[ ! -z "${BUILD_VERSION-}" ]]; then
 	echo $BUILD_VERSION
 	exit 0
 fi
@@ -13,7 +15,7 @@ if [[ "$releases" != *"browser_download_url"* ]]; then
 	exit 1
 fi
 
-release=$(echo "$releases" | python -c 'import json, sys;print json.load(sys.stdin)["name"]')
+release=$(echo "$releases" | python -c 'import json, sys; print(json.load(sys.stdin)["name"])')
 echo $release
 
 exit 0


### PR DESCRIPTION
Also, enabled `euo pipefail` and updated the script accordingly.  If the user was running python3, the `python` command would fail and the `demo-*` targets would continue with an empty `$BUILD_VERSION`.

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>