### PR TITLE
Unable to spin up multiple workers for demo-kubeadm cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,7 @@ cluster-swarm-mode: vagrant-clean
 
 # Brings up a demo cluster to install Contiv on with kubeadm, centos.
 cluster-kubeadm: vagrant-clean
-	cd cluster && \
-	vagrant up kubeadm-master && \
-	vagrant up kubeadm-worker0
+	@bash ./scripts/vagrantup.sh kubeadm
 
 cluster-destroy: vagrant-clean
 


### PR DESCRIPTION
The root cause is due to Makefile always hardcode to spin up
1 master and 1 worker. This PR is to utilize vagrantup.sh to spin
up k8s environment. Whereas vagrantup.sh will take the CONTIV_NODES
and CONTIV_MASTERS which matches the workflow of the Vagrantfile

Signed-off-by: Kahou Lei <kalei@cisco.com>