### PR TITLE
Pin k8s deployment with 1.6.5

### DIFF
--- a/cluster/k8s1.6/bootstrap_centos.sh
+++ b/cluster/k8s1.6/bootstrap_centos.sh
@@ -18,7 +18,7 @@ EOF
 
 setenforce 0
 
-yum install -y docker kubelet kubeadm kubectl kubernetes-cni ntp
+yum install -y docker kubelet-1.6.5 kubeadm-1.6.5 kubectl-1.6.5 kubernetes-cni-1.6.5 ntp
 
 systemctl enable docker && systemctl start docker
 systemctl enable kubelet && systemctl start kubelet


### PR DESCRIPTION
Currently, we don't pin k8s version and therefore it will pose
compatability issues.

This ticket is to pin 1.6 folder. We need to pin 1.4 folder instead
and it will be in a separated ticket.

Signed-off-by: Kahou Lei <kalei@cisco.com>