### PR TITLE
Add extra health check for k8s installation

### DIFF
--- a/install/k8s/install.sh
+++ b/install/k8s/install.sh
@@ -319,6 +319,18 @@ done
 
 set -e
 
+echo "Contiv pods are ready. Creating test pod..."
+# create a test pod and ensure it is running
+$kubectl run -it test-pod --image=contiv/alpine /bin/sh
+
+for i in {0..15}; do
+    sleep 2
+    $kubectl get pods | grep test-pod | grep -v "Running" && continue
+    break
+done
+
+[[ $i -ge 15 ]] && error_ret "unable to run pod !!"
+
 
 echo "Installation is complete"
 echo "========================================================="


### PR DESCRIPTION
Currently, contiv k8s installation only check contiv related pod status.
This is not sufficient enough as there is a chance that we cannot
run any other pod.

This ticket is to enhance k8s installation to ensure that we can
start a regular pod successfully.

Signed-off-by: Kahou Lei <kahou82@gmail.com>