### PR TITLE
Use system proxy

### DIFF
--- a/install/ansible/env.json
+++ b/install/ansible/env.json
@@ -2,7 +2,7 @@
   "docker_version":"__DOCKER_VERSION__", 
   "aci_gw_image":"contiv/aci-gw:__ACI_GW_VERSION__",
   "contiv_network_version":"__CONTIV_VERSION__",
-  "env":{ "http_proxy":"", "HTTP_PROXY":"", "https_proxy":"", "no_proxy":",127.0.0.1,localhost,netmaster" },
+  "env": "{}",
   "etcd_peers_group": "netplugin-master",
   "service_vip": "__NETMASTER_IP__",
   "validate_certs": "no",


### PR DESCRIPTION
The intention of override this env is to provide envrionment vars
in many places of ansible roles (which might be a bad idea), but
force it to use no proxy will ignore whatever has been set on system
level and if there's requirement to do http/https proxy on the host,
it will not be able to reach the internet or other network depends
on the proxy settings. We use use system proxy by default, or override
the proxy settings explicitly if it's required.

Signed-off-by: Wei Tie <wtie@cisco.com>