### PR TITLE
Install branch built v2plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ export CONTIV_ANSIBLE_OWNER ?= contiv
 #export CONTIV_ANSIBLE_IMAGE ?= contiv/install:$(DEFAULT_DOWNLOAD_CONTIV_VERSION)
 export CONTIV_ANSIBLE_IMAGE ?= contiv/install:1.1.7-bash-netcat
 export CONTIV_V2PLUGIN_TARBALL_NAME := v2plugin-$(CONTIV_V2PLUGIN_VERSION).tar.gz
-export CONTIV_ANSIBLE_COMMIT ?= build_v2plugin_on_demand
-export CONTIV_ANSIBLE_OWNER ?= chrisplo
+export CONTIV_ANSIBLE_COMMIT ?= 8e20f56d541af8bc7a3ecbde0d9c64fa943812ed
+export CONTIV_ANSIBLE_OWNER ?= contiv
 
 # this is the classic first makefile target, and it's also the default target
 # run when `make` is invoked with no specific target.

--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,22 @@ export CONTIV_INSTALLER_VERSION ?= $(BUILD_VERSION)
 # downloaded and built assets intended to go in installer by build.sh
 export CONTIV_ARTIFACT_STAGING := $(PWD)/artifact_staging
 # some assets are retrieved from GitHub, this is the default version to fetch
-export DEFAULT_DOWNLOAD_CONTIV_VERSION := 1.1.5
+export DEFAULT_DOWNLOAD_CONTIV_VERSION := 1.1.7
 export CONTIV_ACI_GW_VERSION ?= latest
 export NETPLUGIN_OWNER ?= contiv
 # setting NETPLUGIN_BRANCH compiles that commit on demand,
 # setting CONTIV_NETPLUGIN_VERSION will download that released version
 ifeq ($(NETPLUGIN_BRANCH),)
 export CONTIV_NETPLUGIN_VERSION ?= $(DEFAULT_DOWNLOAD_CONTIV_VERSION)
+export CONTIV_V2PLUGIN_VERSION ?= $(DEFAULT_DOWNLOAD_CONTIV_VERSION)
 else
 export CONTIV_NETPLUGIN_VERSION := $(NETPLUGIN_OWNER)-$(NETPLUGIN_BRANCH)
+export CONTIV_V2PLUGIN_VERSION ?= $(NETPLUGIN_OWNER)-$(NETPLUGIN_BRANCH)
 endif
-export CONTIV_V2PLUGIN_VERSION ?= $(DEFAULT_DOWNLOAD_CONTIV_VERSION)
 export CONTIV_NETPLUGIN_TARBALL_NAME := netplugin-$(CONTIV_NETPLUGIN_VERSION).tar.bz2
-export CONTIV_ANSIBLE_COMMIT ?= 8e20f56d541af8bc7a3ecbde0d9c64fa943812ed
-export CONTIV_ANSIBLE_OWNER ?= contiv
+export CONTIV_V2PLUGIN_TARBALL_NAME := v2plugin-$(CONTIV_V2PLUGIN_VERSION).tar.gz
+export CONTIV_ANSIBLE_COMMIT ?= build_v2plugin_on_demand
+export CONTIV_ANSIBLE_OWNER ?= chrisplo
 
 # this is the classic first makefile target, and it's also the default target
 # run when `make` is invoked with no specific target.
@@ -32,15 +34,15 @@ download-ansible-repo:
 # set NETPLUGIN_OWNER (default contiv) and NETPLUGIN_BRANCH make variables
 # to compile locally
 # e.g. make NETPLUGIN_OWNER=contiv NETPLUGIN_BRANCH=master
-prepare-netplugin-tarball:
-	@scripts/prepare_netplugin_tarball.sh
+prepare-netplugin-artifacts:
+	@./scripts/prepare_netplugin_artifacts.sh
 
 assemble-build:
-	@bash ./scripts/build.sh
+	@./scripts/build.sh
 
 # build creates a release package for contiv.
 # It uses a pre-built image specified by BUILD_VERSION.
-build: download-ansible-repo prepare-netplugin-tarball assemble-build
+build: download-ansible-repo prepare-netplugin-artifacts assemble-build
 
 # ansible-image creates the docker image for ansible container
 # It uses the version specified by BUILD_VERSION or creates an image with the latest tag.

--- a/install/ansible/install.sh
+++ b/install/ansible/install.sh
@@ -128,6 +128,7 @@ if [ "$cluster_store" == "" ]; then
 	cluster_store="etcd://localhost:2379"
 fi
 
+# variables already replaced by build.sh will not pattern match
 sed -i.bak 's#__NETMASTER_IP__#'"$service_vip"'#g' "$env_file"
 sed -i.bak 's#__CLUSTER_STORE__#'"$cluster_store"'#g' "$env_file"
 sed -i.bak 's#__DOCKER_RESET_CONTAINER_STATE__#false#g' "$env_file"

--- a/install/ansible/install_swarm.sh
+++ b/install/ansible/install_swarm.sh
@@ -171,4 +171,5 @@ mounts[4]="-v"
 mounts[5]="$src_conf_path:$container_conf_path:Z"
 mounts[6]="-v"
 mounts[7]="$(pwd)/contiv_cache:/var/contiv_cache:Z"
+set -x
 docker run --rm --net=host "${mounts[@]}" $image_name ./install/ansible/install.sh $netmaster_param -a "$ans_opts" $install_scheduler -m $contiv_network_mode -d $fwd_mode $aci_param $cluster_param $v2plugin_param

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -106,6 +106,13 @@ if [[ -L "${plugin_tball}" ]]; then
 fi
 cp "${plugin_tball}" "${binary_cache}/"
 
+# copy v2plugin assets if built locally on branch
+if [ -n "${NETPLUGIN_BRANCH:-}" ]; then
+    cp "${CONTIV_ARTIFACT_STAGING}"/${CONTIV_V2PLUGIN_TARBALL_NAME} \
+        "${binary_cache}/"
+    cp "${CONTIV_ARTIFACT_STAGING}/config.json" "${binary_cache}/"
+fi
+
 env_file=$output_dir/install/ansible/env.json
 sed -i.bak 's#__AUTH_PROXY_LOCAL_INSTALL__#true#g' "$env_file"
 sed -i.bak 's#__CONTIV_NETWORK_LOCAL_INSTALL__#true#g' "$env_file"

--- a/scripts/prepare_netplugin_artifacts.sh
+++ b/scripts/prepare_netplugin_artifacts.sh
@@ -43,11 +43,16 @@ cd $netplugin_tmp_dir/netplugin
 declare +x BUILD_VERSION
 # this is most likely to be just SHA because we pulled only single commit
 NETPLUGIN_VERSION=$(./scripts/getGitVersion.sh)
-BUILD_VERSION=${NETPLUGIN_VERSION} make tar
+BUILD_VERSION=${NETPLUGIN_VERSION} make tar host-pluginfs-create
 
 # move the netplugin tarball to the staging directory for the installer
-mv netplugin-${NETPLUGIN_VERSION}.tar.bz2 \
-    "${CONTIV_ARTIFACT_STAGING}/"
-# create a link so other scripts can find the file without knowing the SHA
+mv netplugin-${NETPLUGIN_VERSION}.tar.bz2 "${CONTIV_ARTIFACT_STAGING}/"
+# move the v2plugin tarball to the staging directory for the installer
+mv install/v2plugin/v2plugin-${NETPLUGIN_VERSION}.tar.gz "${CONTIV_ARTIFACT_STAGING}/"
+# copy the container's config.json needed to create the v2plugin
+cp install/v2plugin/config.json "${CONTIV_ARTIFACT_STAGING}/"
+
+# create links so other scripts can find the archives without knowing the SHA
 cd "${CONTIV_ARTIFACT_STAGING}"
 ln -sf netplugin-${NETPLUGIN_VERSION}.tar.bz2 $CONTIV_NETPLUGIN_TARBALL_NAME
+ln -sf v2plugin-${NETPLUGIN_VERSION}.tar.gz $CONTIV_V2PLUGIN_TARBALL_NAME


### PR DESCRIPTION
Works with:
https://github.com/contiv/ansible/pull/382

env.json now passes a flag to build the v2plugin at install time or
not, and that flag is managed during build.sh based on if
NETPLUGIN_BRANCH is set during build.

All the scripts and resources in netplugin:install/v2plugin are copied
to the install archive's staging directory then into the installer
archive.

renamed prepare_netplugin_tarball.sh to prepare_netplugin_artifacts.sh
because it does more than just prepare a tarball now

Drive-by:
* Bumps the default contiv version to 1.1.7
* v2plugin version defaults to the default contiv version

Signed-off-by: Chris Plock <chrisplo@cisco.com>