### PR TITLE
ansible SHA for legacy swarm etcd url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export CONTIV_ANSIBLE_OWNER ?= contiv
 #export CONTIV_ANSIBLE_IMAGE ?= contiv/install:$(DEFAULT_DOWNLOAD_CONTIV_VERSION)
 export CONTIV_ANSIBLE_IMAGE ?= contiv/install:1.1.7-bash-netcat
 export CONTIV_V2PLUGIN_TARBALL_NAME := v2plugin-$(CONTIV_V2PLUGIN_VERSION).tar.gz
-export CONTIV_ANSIBLE_COMMIT ?= 8e20f56d541af8bc7a3ecbde0d9c64fa943812ed
+export CONTIV_ANSIBLE_COMMIT ?= 00da7b2a1fd9f631bcfe283a0a640d903ca389f4
 export CONTIV_ANSIBLE_OWNER ?= contiv
 
 # this is the classic first makefile target, and it's also the default target


### PR DESCRIPTION
swarm's etcd on workers should be 127.0.0.1

old code had etcd_proxy listen on all interfaces, #376
removed the ETCD_LISTEN_CLIENT_URLS env var that configured that.

The proxy only listens on 127.0.0.1, but swarm startup script was
pointing to the control interface's IP.

Signed-off-by: Chris Plock <chrisplo@cisco.com>