### PR TITLE
Fixed kubelet RPM and kubeadm token expiry issue

### DIFF
--- a/cluster/k8s1.8/bootstrap_centos.sh
+++ b/cluster/k8s1.8/bootstrap_centos.sh
@@ -20,7 +20,7 @@ setenforce 0
 
 swapoff -a
 
-yum install -y docker kubelet-1.8.4 kubeadm-1.8.4 kubectl-1.8.4 kubernetes-cni-1.8.4 ntp
+yum install -y docker kubeadm-1.8.4 kubectl-1.8.4 kubernetes-cni-1.8.4 ntp
 
 systemctl enable docker && systemctl start docker
 systemctl enable kubelet && systemctl start kubelet

--- a/cluster/k8s1.8/k8smaster.sh
+++ b/cluster/k8s1.8/k8smaster.sh
@@ -1,4 +1,4 @@
-kubeadm init --token=$1 --apiserver-advertise-address=$2 --skip-preflight-checks=true --kubernetes-version $3
+kubeadm init --token-ttl 0 --token=$1 --apiserver-advertise-address=$2 --skip-preflight-checks=true --kubernetes-version $3
 if [ "$#" -eq 4 ]; then
 	cp /etc/kubernetes/admin.conf /home/$4
 	chown $(id -u $4):$(id -g $4) /home/$4/admin.conf


### PR DESCRIPTION
This PR does the following two things:

1. `kubeadm-1.8.4` installs `kubelet-1.8.4` too. Hence, no need to install `kubelet-1.8.4` separately as it causes the following error when running `make demo-kubeadm`:

```
==> kubeadm-master: ---> Package kubelet.x86_64 0:1.8.4-1 will be installed
==> kubeadm-master: --> Processing Dependency: kubernetes-cni = 0.5.1 for package: kubelet-1.8.4-1.x86_64
==> kubeadm-master: --> Finished Dependency Resolution
==> kubeadm-master:  You could try using --skip-broken to work around the problem
==> kubeadm-master: Error: Package: kubelet-1.8.4-1.x86_64 (kubernetes)
==> kubeadm-master:            Requires: kubernetes-cni = 0.5.1
==> kubeadm-master:            Available: kubernetes-cni-0.3.0.1-0.07a8a2.x86_64 (kubernetes)
==> kubeadm-master:                kubernetes-cni = 0.3.0.1-0.07a8a2
==> kubeadm-master:            Available: kubernetes-cni-0.5.1-0.x86_64 (kubernetes)
==> kubeadm-master:                kubernetes-cni = 0.5.1-0
==> kubeadm-master:            Available: kubernetes-cni-0.5.1-1.x86_64 (kubernetes)
==> kubeadm-master:                kubernetes-cni = 0.5.1-1
==> kubeadm-master:            Installing: kubernetes-cni-0.6.0-0.x86_64 (kubernetes)
==> kubeadm-master:                kubernetes-cni = 0.6.0-0
==> kubeadm-master:  You could try running: rpm -Va --nofiles --nodigest
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

2. kubeadm 1.8 expires the token after 24 hours due to:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#behavioral-changes
https://github.com/kubernetes/kubernetes/pull/48783
https://github.com/kubernetes/kubernetes/pull/54640
```
[discovery] Failed to connect to API Server "192.168.2.54:6443": there is no JWS signed token in the cluster-info ConfigMap. This token id "d900e1" is invalid for this cluster, can't connect
```
Hence, make the kubeadm token perpetual so that it does not expire:

https://github.com/kubernetes/kubeadm/issues/335#issuecomment-352521912

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>