### PR TITLE
fix 1.1 with pinned kubeadm

### DIFF
--- a/cluster/k8s1.6/bootstrap_ubuntu.sh
+++ b/cluster/k8s1.6/bootstrap_ubuntu.sh
@@ -15,7 +15,7 @@ EOF
 apt-get update
 # Install docker if you don't have it already.
 apt-get install -y docker.io
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+apt-get install -y kubelet=1.6.5-0 kubeadm=1.6.5-0
 apt-get install -y ntp
 
 systemctl enable ntpd && systemctl start ntpd


### PR DESCRIPTION
upstream packaging failed:
https://github.com/kubernetes/kubernetes/issues/57334

pinning versions for now