### PR TITLE
pin kubernetes package versions

### DIFF
--- a/cluster/k8s1.6/bootstrap_centos.sh
+++ b/cluster/k8s1.6/bootstrap_centos.sh
@@ -18,7 +18,7 @@ EOF
 
 setenforce 0
 
-yum install -y docker kubelet-1.6.5 kubeadm-1.6.5 kubectl-1.6.5 kubernetes-cni-1.6.5 ntp
+yum install -y docker kubelet-1.6.5-0 kubeadm-1.6.5 kubectl-1.6.5-0 kubernetes-cni-0.5.1 ntp
 
 systemctl enable docker && systemctl start docker
 systemctl enable kubelet && systemctl start kubelet


### PR DESCRIPTION
an upstream packaging change requires to be more specific about kubelet and kubectl to allow cni-0.5.1 to be found (uses >= instead of =, since cni 0.5.1 no longer exists, only cni 0.5.1-0 and 0.5.1-1)