### PR TITLE
Makefile: bump version to 1.1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export CONTIV_INSTALLER_VERSION ?= $(BUILD_VERSION)
 # downloaded and built assets intended to go in installer by build.sh
 export CONTIV_ARTIFACT_STAGING := $(PWD)/artifact_staging
 # some assets are retrieved from GitHub, this is the default version to fetch
-export DEFAULT_DOWNLOAD_CONTIV_VERSION := 1.1.7
+export DEFAULT_DOWNLOAD_CONTIV_VERSION := 1.1.8
 export CONTIV_ACI_GW_VERSION ?= latest
 export NETPLUGIN_OWNER ?= contiv
 # setting NETPLUGIN_BRANCH compiles that commit on demand,
@@ -17,7 +17,7 @@ export CONTIV_NETPLUGIN_VERSION := $(NETPLUGIN_OWNER)-$(NETPLUGIN_BRANCH)
 endif
 export CONTIV_V2PLUGIN_VERSION ?= $(DEFAULT_DOWNLOAD_CONTIV_VERSION)
 export CONTIV_NETPLUGIN_TARBALL_NAME := netplugin-$(CONTIV_NETPLUGIN_VERSION).tar.bz2
-export CONTIV_ANSIBLE_COMMIT ?= 2d150b11d623f9301fd11920f02f3a467f0128da
+export CONTIV_ANSIBLE_COMMIT ?= da26cb8ac502255e1272e31b21a8b7dee9783ed9
 export CONTIV_ANSIBLE_OWNER ?= contiv
 
 # this is the classic first makefile target, and it's also the default target


### PR DESCRIPTION
This PR bumps ansible to the latest commit on the release-1.1 branch to include the fix for download failures and it bumps the version to 1.1.8.