### PR TITLE
set selinux-enabled=false to fix the install process

### DIFF
--- a/cluster/k8s1.8/bootstrap_centos.sh
+++ b/cluster/k8s1.8/bootstrap_centos.sh
@@ -22,6 +22,8 @@ swapoff -a
 
 yum install -y docker kubeadm-1.8.4 kubectl-1.8.4 kubernetes-cni-1.8.4 ntp
 
+sed -i -e "s/OPTIONS.*/OPTIONS='--selinux-enabled=false --log-driver=journald --signature-verification=false'/g" /etc/sysconfig/docker
+
 systemctl enable docker && systemctl start docker
 systemctl enable kubelet && systemctl start kubelet
 systemctl enable ntpd && systemctl start ntpd


### PR DESCRIPTION
**Problem:** the install process of `make cluster-kubeadm` exits with:

```
    kubeadm-master: Created symlink from /etc/systemd/system/multi-user.target.wants/docker.service to /usr/lib/systemd/system/docker.service.
    kubeadm-master: Job for docker.service failed because the control process exited with error code. See "systemctl status docker.service" and "journalctl -xe" for details.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

**Reason:** Docker 1.13 doesn't come up with selinux enabled. 

**Solution:** This pull request sets the selinux option to false and the install process goes through.